### PR TITLE
Add team status reporting utility

### DIFF
--- a/src/WithSecure/common/team_report.py
+++ b/src/WithSecure/common/team_report.py
@@ -1,0 +1,30 @@
+"""Utilities for reporting the success or failure of teams."""
+
+from . import logger
+
+
+def report_team_status(team_results):
+    """Report team results to the drozer logger and return a summary string.
+
+    Parameters
+    ----------
+    team_results : dict
+        Mapping of team names to a boolean indicating success (True) or
+        failure (False).
+
+    Returns
+    -------
+    str
+        A string summarising the team results in the form
+        "<team>: SUCCESS" or "<team>: FAILURE" on separate lines.
+    """
+    lines = []
+    for team, success in team_results.items():
+        status = "SUCCESS" if success else "FAILURE"
+        message = f"{team}: {status}"
+        if success:
+            logger.logger.info(message)
+        else:
+            logger.logger.warning(message)
+        lines.append(message)
+    return "\n".join(lines)

--- a/test/mwr_test/common/team_report_test.py
+++ b/test/mwr_test/common/team_report_test.py
@@ -1,0 +1,19 @@
+import unittest
+from WithSecure.common.team_report import report_team_status
+
+
+class TeamReportTestCase(unittest.TestCase):
+    def test_report_output(self):
+        result = report_team_status({'alpha': True, 'beta': False})
+        self.assertIn('alpha: SUCCESS', result)
+        self.assertIn('beta: FAILURE', result)
+
+
+def TeamReportTestSuite():
+    suite = unittest.TestSuite()
+    suite.addTest(TeamReportTestCase('test_report_output'))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner().run(TeamReportTestSuite())


### PR DESCRIPTION
## Summary
- add `report_team_status` utility for logging team results
- test team status reporting logic

## Testing
- `PYTHONPATH=src python test/mwr_test/common/team_report_test.py`


------
https://chatgpt.com/codex/tasks/task_e_684f5050027c8326b4884169c7ed27dc